### PR TITLE
release prep 2024.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ The version format should be `YYYY.mM.seq`. For example: the *third* version rel
 
 ## [Unreleased]
 
+
+## [2024.7.1] - 2024-07-28
 ### Added
 - United Kingdom (`uk_hf`, `uk_vhf`) band charts.
 - Bulgarian (`bg`) band chart.
@@ -85,7 +87,8 @@ The version format should be `YYYY.mM.seq`. For example: the *third* version rel
 - MD5 hashes for all files in the index.
 
 
-[Unreleased]: https://github.com/miaowware/qrm-resources/compare/v2024.1.2...HEAD
+[Unreleased]: https://github.com/miaowware/qrm-resources/compare/v2024.7.1...HEAD
+[2024.7.1]: https://github.com/miaowware/qrm-resources/releases/tag/v2024.7.1
 [2024.1.2]: https://github.com/miaowware/qrm-resources/releases/tag/v2024.1.2
 [2024.1.1]: https://github.com/miaowware/qrm-resources/releases/tag/v2024.1.1
 [2021.12.1]: https://github.com/miaowware/qrm-resources/releases/tag/v2021.12.1

--- a/gethashes.py
+++ b/gethashes.py
@@ -10,7 +10,7 @@ Released under the terms of the BSD 3-Clause license.
 import binascii
 import hashlib
 import json
-from datetime import datetime
+from datetime import datetime, UTC
 from pathlib import Path
 
 
@@ -39,7 +39,7 @@ for resource, versions in index["resources"].items():
             index["resources"][resource][version][file_idx]["hash"] = str(binascii.hexlify(hashed.digest()), "utf-8")
 
 
-index["last_updated"] = datetime.utcnow().isoformat() + "Z"
+index["last_updated"] = datetime.now(UTC).isoformat()
 
 
 print("Writing the hashes...")

--- a/resources/index.json
+++ b/resources/index.json
@@ -1,11 +1,11 @@
 {
-    "last_updated": "2024-01-06T08:42:15.710350Z",
+    "last_updated": "2024-07-28T06:25:42.403236+00:00",
     "resources": {
         "bandcharts": {
             "v1": [
                 {
                     "filename": "bandcharts.1.json",
-                    "hash": "0b5b04d9fbe71a951af1241b8e5908b2"
+                    "hash": "ec0126e60408090de5edacf74b6846d3"
                 }
             ]
         },


### PR DESCRIPTION

### Description

- gethashes.py: remove usage of deprecated datetime.utcnow()
- resources/index.json: update
- CHANGELOG.md: update for 2024.7.1 release

### Type of change

<!-- Please delete options that are not relevant. -->

- release prep

### How has this been tested?

<!-- Describe the procedure used for verifying your changes here. -->

### Checklist

- [ ] Issue exists for PR
- [x] Code reviewed by the author
- [ ] Code documented (comments or other documentation)
- [x] Changes tested
- [ ] All tests pass (see [`DEVELOPING.md`][0], if it exists)
- [x] [`CHANGELOG.md`][1] updated if needed
- [x] Informative commit messages
- [x] Descriptive PR title

[0]: /DEVELOPING.md
[1]: /CHANGELOG.md
